### PR TITLE
SME-3: ENV as Context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 *.db
 *.env*
 __pycache__
+.coverage.*
 .coverage
 htmlcov
 *egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+### 2022-01-13 - v.1.0.3
+
+* ENV now is a context manager (enabling auto type cast within)
+* Fixed a bug of setting _auto_type_cast
+* Added missed py35 configuration in tox.ini
+* Fixed .gitignore about coverage files
+* Fixed tests (cleanup)
+* Added test for ENV as context manager
+
+
 ### 2020-02-15 - v.1.0.2
 
 * Added support for operator "in"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ tox -e <env>
 
 Tests coverage is one of the important goals of this project.
 For now coverage is next:
-- For Python 2.7: 98%
-- For Python 3.x: 97%
+- For Python 2.7: 95%
+- For Python 3.x: 95%
 
 Supported environments:
 

--- a/README.md
+++ b/README.md
@@ -55,16 +55,22 @@ This library contains tests written using *unittest* module, so just run in the 
 python -m unittest
 ```
 
-Also it's possible to run tests using Tox:
+It's possible to run tests using Tox as well:
 
 ```bash
 tox -e <env>
 ```
 
+or even just
+
+```bash
+tox
+```
+
 Tests coverage is one of the important goals of this project.
 For now coverage is next:
-- For Python 2.7: 95%
-- For Python 3.x: 95%
+- For Python 2.7: 98%
+- For Python 3.x: 97%
 
 Supported environments:
 

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,11 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'),
 
 setup(
     name='smart-env',
-    version='1.0.2',
+    version='1.0.3',
     description='Smart Environment Wrapper Library',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/bart-tools/smart-env',
+    url='https://github.com/atcode-space/smart-env',
     author='Alex Sokolov',
     author_email='volokos.alex@gmail.com',
     classifiers=[
@@ -65,7 +65,6 @@ setup(
     ],
 
     project_urls={
-        'Source': 'https://github.com/bart-tools/smart-env/',
-        'Project': 'https://github.com/bart-tools'
+        'Source': 'https://github.com/atcode-space/smart-env/',
     },
 )

--- a/tests/test_env_methods.py
+++ b/tests/test_env_methods.py
@@ -24,13 +24,17 @@ THE SOFTWARE.
 
 import datetime
 import itertools
+import os
 from time import time
 import unittest
 
 from smart_env import ENV
 
 
-__all__ = ('EnvTestCase',)
+__all__ = (
+    'EnvTestCase',
+    'ENVRepresentationTestCase'
+)
 
 
 class EnvTestCase(unittest.TestCase):
@@ -136,14 +140,31 @@ class EnvTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             ENV._ENV__decode(object())
 
+    def test_012_env_as_context_manager(self):
+        """Check ENV's behaviour as a context manager"""
+
+        for method, assertFn in (
+            ('disable_automatic_type_cast', self.assertFalse),
+            ('enable_automatic_type_cast', self.assertTrue)
+        ):
+            getattr(ENV, method)()
+            assertFn(ENV.is_auto_type_cast())
+            with ENV:
+                self.assertTrue(ENV.is_auto_type_cast())
+            assertFn(ENV.is_auto_type_cast())
+
+    def tearDown(self):
+        ENV.disable_automatic_type_cast()
+
 
 class ENVRepresentationTestCase(unittest.TestCase):
     """Test cases for representations of ENV class"""
 
     def setUp(self):
         """Erase environment before running tests"""
+        ENV.disable_automatic_type_cast()
 
-        for var in ENV:
+        for var in list(os.environ):
             setattr(ENV, var, None)
 
     def test_001_test_str_method(self):
@@ -193,3 +214,6 @@ class ENVRepresentationTestCase(unittest.TestCase):
         )
 
         self.assertEqual(dir(ENV), dir_list)
+
+    def tearDown(self):
+        ENV.disable_automatic_type_cast()

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 [tox]
-envlist = py27,py36,py37,py38,coverage,coverage27,pep8
+envlist = py27,py35,py36,py37,py38,coverage,coverage27,pep8
 
 
 [testenv]
@@ -34,7 +34,7 @@ commands = python -m unittest discover -p "test_*.py"
 
 [testenv:pep8]
 deps = pycodestyle
-commands = pycodestyle --exclude=.tox,.venv,.env, .
+commands = pycodestyle --exclude=.tox,.venv,.env,venv,env .
 
 
 [testenv:coverage]


### PR DESCRIPTION
Changes:
    - ENV now is a context manager (enabling auto type cast within)
    - Fixed a bug of setting _auto_type_cast
    - Added missed py35 configuration in tox.ini
    - Fixed .gitignore about coverage files
    - Fixed tests (cleanup)
    - Added test for ENV as context manager